### PR TITLE
downgrade most F1Es to F1s

### DIFF
--- a/dj_config_updates.json
+++ b/dj_config_updates.json
@@ -11,35 +11,35 @@ addEntityType AIRCRAFT
 addFeature  {"feature": "DJ_PROFILE_ID", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "DJ_PROFILE_ID", "class": "IDENTIFIER", "feature": "DJ_PROFILE_ID", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "OFAC_ID", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
+addFeature  {"feature": "OFAC_ID", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "OFAC_ID", "class": "IDENTIFIER", "feature": "OFAC_ID", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "NCIC_NUMBER", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
+addFeature  {"feature": "NCIC_NUMBER", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "NCIC_NUMBER", "class": "IDENTIFIER", "feature": "NCIC_NUMBER", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "CRD_NUMBER", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
+addFeature  {"feature": "CRD_NUMBER", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "CRD_NUMBER", "class": "IDENTIFIER", "feature": "CRD_NUMBER", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "COMPANY_ID", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "PARSE_ID", "expression": "EXPRESS_ID", "comparison": "ID_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "No"}, {"element": "COUNTRY", "expressed": "No", "compared": "Yes"}, {"element": "ID_NUM_STD", "expressed": "Yes", "compared": "Yes"}]}
+addFeature  {"feature": "COMPANY_ID", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "PARSE_ID", "expression": "EXPRESS_ID", "comparison": "ID_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "No"}, {"element": "COUNTRY", "expressed": "No", "compared": "Yes"}, {"element": "ID_NUM_STD", "expressed": "Yes", "compared": "Yes"}]}
 addAttribute {"attribute": "COMPANY_ID_NUMBER", "class": "IDENTIFIER", "feature": "COMPANY_ID", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 addAttribute {"attribute": "COMPANY_ID_COUNTRY", "class": "IDENTIFIER", "feature": "COMPANY_ID", "element": "COUNTRY", "required": "No", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "ISIN_NUM", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
+addFeature  {"feature": "ISIN_NUM", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "ISIN_NUMBER", "class": "IDENTIFIER", "feature": "ISIN_NUM", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
 addAttribute {"attribute": "IMO_NUMBER", "class": "IDENTIFIER", "feature": "IMO_NUM", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 addAttribute {"attribute": "MMSI_NUMBER", "class": "IDENTIFIER", "feature": "MMSI_NUM", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "AIRCRAFT_MSN", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
+addFeature  {"feature": "AIRCRAFT_MSN", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "AIRCRAFT_MSN", "class": "IDENTIFIER", "feature": "AIRCRAFT_MSN", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
 addFeature  {"feature": "AIRCRAFT_TAIL_NUMBER", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "AIRCRAFT_TAIL_NUMBER", "class": "IDENTIFIER", "feature": "AIRCRAFT_TAIL_NUMBER", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "MSB_LICENSE", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
+addFeature  {"feature": "MSB_LICENSE", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "MSB_LICENSE_NUMBER", "class": "IDENTIFIER", "feature": "MSB_LICENSE", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
-addFeature  {"feature": "MARIJUANA_LICENSE", "class": "ISSUED_ID", "behavior": "F1E", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
+addFeature  {"feature": "MARIJUANA_LICENSE", "class": "ISSUED_ID", "behavior": "F1", "anonymize": "No", "candidates": "Yes", "standardize": "", "expression": "", "comparison": "EXACT_COMP", "elementList": [{"element": "ID_NUM", "expressed": "No", "compared": "Yes"}]}
 addAttribute {"attribute": "MARIJUANA_LICENSE_NUMBER", "class": "IDENTIFIER", "feature": "MARIJUANA_LICENSE", "element": "ID_NUM", "required": "Yes", "default": "", "advanced": "No", "internal": "No"}
 
 save


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Some companies have multiple company IDs, marijuana licenses, etc.  All F1s identifiers were reviewed and the exclusive behavior was removed unless it should actually break matches.